### PR TITLE
Fix bug in TransitionBasedParser_v1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 3.0.7
+version = 3.0.8
 description = Legacy registered functions for spaCy backwards compatibility
 url = https://spacy.io
 author = Explosion

--- a/spacy_legacy/architectures/parser.py
+++ b/spacy_legacy/architectures/parser.py
@@ -47,4 +47,46 @@ def TransitionBasedParser_v1(
             upper = Linear(nO=nO, init_W=zero_init)
     else:
         upper = None
-    return TransitionModel(tok2vec, lower, upper)
+    return TransitionModel(tok2vec, lower, upper, resize_output=resize_output_v1)
+
+
+def resize_output_v1(model, new_nO):
+    Linear = registry.get("layers", "Linear.v1")
+
+    lower = model.get_ref("lower")
+    upper = model.get_ref("upper")
+    if not model.attrs["has_upper"]:
+        if lower.has_dim("nO") is None:
+            lower.set_dim("nO", new_nO)
+        return
+    elif upper.has_dim("nO") is None:
+        upper.set_dim("nO", new_nO)
+        return
+    elif new_nO == upper.get_dim("nO"):
+        return
+    smaller = upper
+    nI = None
+    if smaller.has_dim("nI"):
+        nI = smaller.get_dim("nI")
+    with use_ops("numpy"):
+        larger = Linear(nO=new_nO, nI=nI)
+        larger.init = smaller.init
+    # it could be that the model is not initialized yet, then skip this bit
+    if nI:
+        larger_W = larger.ops.alloc2f(new_nO, nI)
+        larger_b = larger.ops.alloc1f(new_nO)
+        smaller_W = smaller.get_param("W")
+        smaller_b = smaller.get_param("b")
+        # Weights are stored in (nr_out, nr_in) format, so we're basically
+        # just adding rows here.
+        if smaller.has_dim("nO"):
+            larger_W[: smaller.get_dim("nO")] = smaller_W
+            larger_b[: smaller.get_dim("nO")] = smaller_b
+            for i in range(smaller.get_dim("nO"), new_nO):
+                model.attrs["unseen_classes"].add(i)
+
+        larger.set_param("W", larger_W)
+        larger.set_param("b", larger_b)
+    model._layers[-1] = larger
+    model.set_ref("upper", larger)
+    return model


### PR DESCRIPTION
`TransitionModel` has been changed to take a `resize_output` - quick fix to ensure old configs keep working