### PR TITLE
Replace registry imports with registry.get()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Development requirements
-spacy>=3.0.6,<3.1.0
+spacy>=3.0.7,<3.1.0
 pytest>=5.0.1

--- a/spacy_legacy/architectures/parser.py
+++ b/spacy_legacy/architectures/parser.py
@@ -7,10 +7,6 @@ from spacy.compat import Literal
 from spacy.errors import Errors
 from spacy.util import registry
 
-# TODO: replace with registered layers after spacy is released with the update
-from spacy.ml._precomputable_affine import PrecomputableAffine
-from spacy.ml.tb_framework import TransitionModel
-
 
 def TransitionBasedParser_v1(
     tok2vec: Model[List[Doc], List[Floats2d]],
@@ -25,6 +21,8 @@ def TransitionBasedParser_v1(
     chain = registry.get("layers", "chain.v1")
     list2array = registry.get("layers", "list2array.v1")
     Linear = registry.get("layers", "Linear.v1")
+    TransitionModel = registry.get("layers", "spacy.TransitionModel.v1")
+    PrecomputableAffine = registry.get("layers", "spacy.PrecomputableAffine.v1")
 
     if state_type == "parser":
         nr_feature_tokens = 13 if extra_state_tokens else 8

--- a/spacy_legacy/architectures/textcat.py
+++ b/spacy_legacy/architectures/textcat.py
@@ -5,9 +5,6 @@ from spacy.attrs import ID, ORTH, PREFIX, SUFFIX, SHAPE, LOWER
 from spacy.util import registry
 from spacy.tokens import Doc
 
-# TODO: replace with registered layer after spacy v3.0.7
-from spacy.ml import extract_ngrams
-
 
 def TextCatCNN_v1(
     tok2vec: Model, exclusive_classes: bool, nO: Optional[int] = None
@@ -24,8 +21,6 @@ def TextCatCNN_v1(
     Softmax = registry.get("layers", "Softmax.v1")
     Linear = registry.get("layers", "Linear.v1")
     list2ragged = registry.get("layers", "list2ragged.v1")
-
-    # extract_ngrams = registry.get("layers", "spacy.extract_ngrams.v1")
 
     with Model.define_operators({">>": chain}):
         cnn = tok2vec >> list2ragged() >> reduce_mean()
@@ -53,6 +48,7 @@ def TextCatBOW_v1(
     Logistic = registry.get("layers", "Logistic.v1")
     SparseLinear = registry.get("layers", "SparseLinear.v1")
     softmax_activation = registry.get("layers", "softmax_activation.v1")
+    extract_ngrams = registry.get("layers", "spacy.extract_ngrams.v1")
 
     with Model.define_operators({">>": chain}):
         sparse_linear = SparseLinear(nO)

--- a/spacy_legacy/loggers.py
+++ b/spacy_legacy/loggers.py
@@ -3,7 +3,7 @@ import sys
 
 from spacy import util
 from spacy.errors import Errors
-from spacy.training.loggers import console_logger
+from spacy.util import registry
 
 
 def wandb_logger_v1(project_name: str, remove_config_values: List[str] = []):
@@ -13,6 +13,7 @@ def wandb_logger_v1(project_name: str, remove_config_values: List[str] = []):
     except ImportError:
         raise ImportError(Errors.E880)
 
+    console_logger = registry.get("layers", "spacy.ConsoleLogger.v1")
     console = console_logger(progress_bar=False)
 
     def setup_logger(

--- a/spacy_legacy/loggers.py
+++ b/spacy_legacy/loggers.py
@@ -13,7 +13,7 @@ def wandb_logger_v1(project_name: str, remove_config_values: List[str] = []):
     except ImportError:
         raise ImportError(Errors.E880)
 
-    console_logger = registry.get("layers", "spacy.ConsoleLogger.v1")
+    console_logger = registry.get("loggers", "spacy.ConsoleLogger.v1")
     console = console_logger(progress_bar=False)
 
     def setup_logger(


### PR DESCRIPTION

With the correct spaCy version available, imports such as `from spacy.ml import extract_ngram` are replaced with 

`extract_ngrams = registry.get("layers", "spacy.extract_ngrams.v1")` .

## Changes in:
- architecture/textcat.py
- architecture/parser.py
- loggers.py
