### PR TITLE
Increment version to v3.1.0

### DIFF
--- a/bin/push-tag.sh
+++ b/bin/push-tag.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Insist repository is clean
+git diff-index --quiet HEAD
+
+git checkout $1
+git pull origin $1
+git push origin $1
+
+version=$(grep "__version__ = " spacy/about.py)
+version=${version/__version__ = }
+version=${version/\'/}
+version=${version/\'/}
+version=${version/\"/}
+version=${version/\"/}
+git tag "v$version"
+git push origin "v$version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 3.0.9
+version = 3.1.0
 description = Legacy registered functions for spaCy backwards compatibility
 url = https://spacy.io
 author = Explosion


### PR DESCRIPTION
This `PR` increments the `spacy-legacy` version to `v3.1.0` and adds the `push-tag.sh` script